### PR TITLE
Add helm chart, 7Zip and custom s3 endpoints for wasabi/DO etc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+helm/*
+images/*
+kubernetes/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+**/.DS_Store
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mongo:latest
 
 RUN apt update && \
-    apt install awscli -y
+    apt install awscli p7zip-full -y
 
 WORKDIR /scripts
 
@@ -13,6 +13,12 @@ ENV MONGODB_URI="" \
     BUCKET_URI="" \
     AWS_ACCESS_KEY_ID="" \
     AWS_SECRET_ACCESS_KEY="" \
-    AWS_DEFAULT_REGION=""
+    AWS_DEFAULT_REGION="" \
+    S3_ENDPOINT_URL="" \
+    PASSWORD_7ZIP=""
+
+RUN apt-get clean autoclean && \
+    apt-get autoremove --yes && \
+    rm -rf /var/lib/apt/lists/*
 
 CMD ["/scripts/backup-mongodb.sh"]

--- a/backup-mongodb.sh
+++ b/backup-mongodb.sh
@@ -17,10 +17,24 @@ mongodump $OPLOG_FLAG \
 	--gzip \
 	--uri "$MONGODB_URI"
 
+COPY_NAME=$ARCHIVE_NAME
+if [ ! -z "$PASSWORD_7ZIP" ]; then
+    echo "[$SCRIPT_NAME] 7Zipping with password..."
+    COPY_NAME=mongodump_$(date +%Y%m%d_%H%M%S).7z
+    7za a -tzip -p"$PASSWORD_7ZIP" -mem=AES256 "$COPY_NAME" "$ARCHIVE_NAME"
+fi
+
+
+S3_ENDPOINT_OPT=""
+if [ ! -z "$S3_ENDPOINT_URL" ]; then
+  S3_ENDPOINT_OPT="--endpoint-url $S3_ENDPOINT_URL"
+fi
+
 echo "[$SCRIPT_NAME] Uploading compressed archive to S3 bucket..."
-aws s3 cp "$ARCHIVE_NAME" "$BUCKET_URI"
+aws ${S3_ENDPOINT_OPT} s3 cp "$COPY_NAME" "$BUCKET_URI/$COPY_NAME"
 
 echo "[$SCRIPT_NAME] Cleaning up compressed archive..."
-rm "$ARCHIVE_NAME"
+rm "$COPY_NAME"
+rm "$ARCHIVE_NAME" || true
 
 echo "[$SCRIPT_NAME] Backup complete!"

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: k8s-backup-mongodb
+description: Mongo db backup as a cronjob - helm package
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-backup-mongodb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-backup-mongodb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-backup-mongodb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "k8s-backup-mongodb.labels" -}}
+helm.sh/chart: {{ include "k8s-backup-mongodb.chart" . }}
+{{ include "k8s-backup-mongodb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8s-backup-mongodb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-backup-mongodb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "k8s-backup-mongodb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "k8s-backup-mongodb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-mongodb
+  namespace: backup-mongodb
+spec:
+  schedule: {{ .Values.schedule | quote}}
+  concurrencyPolicy: Forbid
+  suspend: false
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: backup-mongodb
+            image: {{ .Values.image }}
+            env:
+            - name: MONGODB_URI
+              value: {{ .Values.mongoDbUri | quote}}
+            - name: MONGODB_OPLOG
+              value: {{ .Values.withOplog | quote}}
+            - name: BUCKET_URI
+              value: {{ .Values.bucketUri | quote }}
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.awsAccessKeyId | quote}}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.awsSecretAccessKey | quote }}
+            - name: AWS_DEFAULT_REGION
+              value: {{ .Values.awsDefaultRegion | quote}}
+            - name: S3_ENDPOINT_URL
+              value: {{ .Values.s3EndpointUrl | quote }}
+            - name: PASSWORD_7ZIP
+              value: {{ .Values.password7Zip | quote }}
+
+
+

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backup-mongodb

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,15 @@
+# Default values for k8s-backup-mongodb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+schedule: "\"0 1 * * *\""
+image: "ptuladhar/k8s-backup-mongodb:latest"
+
+withOplog: true
+mongoDbUri: ""
+bucketUri: ""
+awsAccessKeyId: ""
+awsSecretAccessKey: ""
+s3EndpointUrl: ""
+awsDefaultRegion: ""
+password7Zip: ""


### PR DESCRIPTION
Hello @tuladhar 

many thanks for your k8s mongo backup cronjob. I modified it a bit for my use case which I'd like to share

- Added optional different s3 endpoint for S3 compatible services like wasabi/digitalocean etc.
- Added  7zip + password functionality. Obviously you should never allow anyone access to the bucket with your db backups but this could be an extra hurdle should something happen
- Made the choice of image configurable 
- Made a helm chart out of it for deployment ease / in automation  (todo if approved, make it available as repo)

Please let me know what you think. Again many thanks!